### PR TITLE
Creating a library explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ readme = "./README.md"
 keywords = ["rsync", "linux", "file", "cli", "sync"]
 categories = ["command-line-utilities", "filesystem", ]
 
+[lib]
+name = "lms"
+path = "src/lib.rs"
+
+[[bin]]
+name = "lms"
+path = "src/main.rs"
+
 [badges]
 travis-ci = { repository = "wchang22/LuminS", branch = "master" }
 codecov = { repository = "wchang22/LuminS", branch = "master", service = "github" }


### PR DESCRIPTION
With this commit not only a binary but also a library is created. So
this crate can now also be used as a "library only".

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>